### PR TITLE
Add script viewer and execution dialogs

### DIFF
--- a/App1.Core/Models/ScriptInfo.cs
+++ b/App1.Core/Models/ScriptInfo.cs
@@ -1,3 +1,5 @@
+using Newtonsoft.Json.Linq;
+
 namespace App1.Core.Models;
 
 public class ScriptInfo
@@ -7,4 +9,6 @@ public class ScriptInfo
     public string SourceUrl { get; set; }
     public int Rating { get; set; }
     public int Risk { get; set; }
+    public string JsonUrl { get; set; }
+    public JObject Definition { get; set; }
 }

--- a/App1.Core/Services/ScriptRepositoryService.cs
+++ b/App1.Core/Services/ScriptRepositoryService.cs
@@ -39,7 +39,9 @@ public class ScriptRepositoryService : IScriptRepositoryService
                         Description = script.Value<string>("description"),
                         SourceUrl = script.Value<string>("source_url"),
                         Rating = script.Value<int?>("rating") ?? 0,
-                        Risk = script.Value<int?>("risk") ?? 0
+                        Risk = script.Value<int?>("risk") ?? 0,
+                        JsonUrl = downloadUrl,
+                        Definition = obj
                     });
                 }
             }

--- a/App1/Views/ListDetailsPage.xaml
+++ b/App1/Views/ListDetailsPage.xaml
@@ -80,7 +80,8 @@
         <Button
             Grid.Column="1"
             Margin="417,402,18,18"
-            Content="Prepare Script" />
+            Content="Prepare Script"
+            Click="OnPrepareScript" />
         <ContentControl
             Grid.Column="1"
             ContentTemplate="{StaticResource DetailTemplate}"
@@ -88,6 +89,7 @@
         <Button
             Grid.Column="1"
             Margin="304,402,131,18"
-            Content="View Full Script" />
+            Content="View Full Script"
+            Click="OnViewScript" />
     </Grid>
 </Page>

--- a/App1/Views/ListDetailsPage.xaml.cs
+++ b/App1/Views/ListDetailsPage.xaml.cs
@@ -2,6 +2,9 @@
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Windows.Controls;
+using System.Net.Http;
+using App1.Views;
+using System.Linq;
 
 using App1.Contracts.Views;
 using App1.Core.Contracts.Services;
@@ -62,4 +65,22 @@ public partial class ListDetailsPage : Page, INotifyPropertyChanged, INavigation
     }
 
     private void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+    private async void OnViewScript(object sender, System.Windows.RoutedEventArgs e)
+    {
+        if (Selected == null || string.IsNullOrEmpty(Selected.SourceUrl)) return;
+        var client = new HttpClient();
+        var text = await client.GetStringAsync(Selected.SourceUrl);
+        var dlg = new ScriptViewWindow(text);
+        dlg.Owner = System.Windows.Window.GetWindow(this);
+        dlg.ShowDialog();
+    }
+
+    private void OnPrepareScript(object sender, System.Windows.RoutedEventArgs e)
+    {
+        if (Selected == null) return;
+        var dlg = new ScriptExecutionWindow(Selected);
+        dlg.Owner = System.Windows.Window.GetWindow(this);
+        dlg.ShowDialog();
+    }
 }

--- a/App1/Views/ScriptExecutionWindow.xaml
+++ b/App1/Views/ScriptExecutionWindow.xaml
@@ -1,0 +1,20 @@
+<controls:MetroWindow
+    x:Class="App1.Views.ScriptExecutionWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="http://metro.mahapps.com/winfx/xaml/controls"
+    Title="Execute Script" Height="500" Width="600">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <StackPanel x:Name="InputsPanel" />
+        <RichTextBox x:Name="OutputBox" Grid.Row="1" Margin="0,10" IsReadOnly="True"/>
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10">
+            <Button x:Name="CancelButton" Width="80" Margin="5" Click="Cancel_Click">Cancel</Button>
+            <Button x:Name="ExecuteButton" Width="80" Margin="5" Click="Execute_Click">Execute</Button>
+        </StackPanel>
+    </Grid>
+</controls:MetroWindow>

--- a/App1/Views/ScriptExecutionWindow.xaml.cs
+++ b/App1/Views/ScriptExecutionWindow.xaml.cs
@@ -1,0 +1,129 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using MahApps.Metro.Controls;
+using Newtonsoft.Json.Linq;
+using System.Management.Automation;
+using App1.Core.Models;
+
+namespace App1.Views;
+
+public partial class ScriptExecutionWindow : MetroWindow
+{
+    private readonly ScriptInfo _info;
+    private readonly Dictionary<string, Control> _controls = new();
+
+    public ScriptExecutionWindow(ScriptInfo info)
+    {
+        InitializeComponent();
+        _info = info;
+        BuildInputs();
+    }
+
+    private void BuildInputs()
+    {
+        var inputs = _info.Definition?["inputs"] as JArray;
+        if (inputs == null) return;
+        foreach (var item in inputs)
+        {
+            var labelText = item.Value<string>("label") ?? item.Value<string>("name");
+            var name = item.Value<string>("name") ?? string.Empty;
+            var type = item.Value<string>("ControlType")?.ToLower();
+            if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(type)) continue;
+
+            var label = new TextBlock { Text = labelText, Margin = new Thickness(0,5,0,0) };
+            InputsPanel.Children.Add(label);
+
+            Control control = null;
+            switch (type)
+            {
+                case "textbox":
+                    control = new TextBox { Text = item.Value<string>("default") ?? string.Empty };
+                    break;
+                case "checkedlistbox":
+                    var lb = new ListBox { SelectionMode = SelectionMode.Multiple, Height = 100 };
+                    foreach (var choice in item["items"] as JArray ?? new JArray())
+                    {
+                        var chk = new CheckBox { Content = choice["Label"]?.ToString() ?? choice.ToString(), Tag = choice["ID"]?.ToString() };
+                        lb.Items.Add(chk);
+                    }
+                    control = lb;
+                    break;
+                case "combobox":
+                    var cb = new ComboBox();
+                    foreach (var choice in item["items"] as JArray ?? new JArray())
+                    {
+                        cb.Items.Add(choice.ToString());
+                    }
+                    cb.SelectedIndex = 0;
+                    control = cb;
+                    break;
+                case "datetimepicker":
+                    control = new DatePicker();
+                    break;
+            }
+            if (control != null)
+            {
+                _controls[name] = control;
+                InputsPanel.Children.Add(control);
+            }
+        }
+    }
+
+    private void Cancel_Click(object sender, RoutedEventArgs e)
+    {
+        DialogResult = false;
+        Close();
+    }
+
+    private async void Execute_Click(object sender, RoutedEventArgs e)
+    {
+        ExecuteButton.IsEnabled = false;
+        OutputBox.Document.Blocks.Clear();
+
+        try
+        {
+            var client = new HttpClient();
+            var script = await client.GetStringAsync(_info.SourceUrl);
+            using var ps = PowerShell.Create();
+            ps.AddScript(script);
+            foreach (var kvp in _controls)
+            {
+                object val = null;
+                switch (kvp.Value)
+                {
+                    case TextBox tb:
+                        val = tb.Text; break;
+                    case ComboBox cb:
+                        val = cb.SelectedItem; break;
+                    case DatePicker dp:
+                        val = dp.SelectedDate; break;
+                    case ListBox lb:
+                        val = lb.Items.OfType<CheckBox>().Where(c => c.IsChecked == true).Select(c => c.Tag ?? c.Content).ToArray();
+                        break;
+                }
+                ps.AddParameter(kvp.Key, val);
+            }
+            var results = await Task.Run(() => ps.Invoke());
+            foreach (var r in results)
+            {
+                OutputBox.AppendText(r?.ToString() + "\n");
+            }
+            foreach (var err in ps.Streams.Error)
+            {
+                OutputBox.AppendText(err.ToString() + "\n");
+            }
+        }
+        catch (System.Exception ex)
+        {
+            OutputBox.AppendText(ex.ToString());
+        }
+        finally
+        {
+            ExecuteButton.IsEnabled = true;
+        }
+    }
+}

--- a/App1/Views/ScriptViewWindow.xaml
+++ b/App1/Views/ScriptViewWindow.xaml
@@ -1,0 +1,12 @@
+<controls:MetroWindow
+    x:Class="App1.Views.ScriptViewWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="http://metro.mahapps.com/winfx/xaml/controls"
+    Title="Script" Height="450" Width="800">
+    <Grid>
+        <ScrollViewer>
+            <TextBox x:Name="ScriptTextBox" IsReadOnly="True" TextWrapping="Wrap" FontFamily="Consolas" Background="Transparent" BorderThickness="0"/>
+        </ScrollViewer>
+    </Grid>
+</controls:MetroWindow>

--- a/App1/Views/ScriptViewWindow.xaml.cs
+++ b/App1/Views/ScriptViewWindow.xaml.cs
@@ -1,0 +1,12 @@
+using MahApps.Metro.Controls;
+
+namespace App1.Views;
+
+public partial class ScriptViewWindow : MetroWindow
+{
+    public ScriptViewWindow(string scriptText)
+    {
+        InitializeComponent();
+        ScriptTextBox.Text = scriptText;
+    }
+}


### PR DESCRIPTION
## Summary
- extend `ScriptInfo` to hold JSON definition
- expose JsonUrl and Definition in `ScriptRepositoryService`
- add `ScriptViewWindow` for displaying script text
- add `ScriptExecutionWindow` to run scripts with dynamic input form and output box
- wire up buttons on `ListDetailsPage` to open these dialogs

## Testing
- `dotnet build App1.sln -c Release` *(fails: NETSDK1100 EnableWindowsTargeting)*

------
https://chatgpt.com/codex/tasks/task_e_6841253ba0208326862c659b57139eb0